### PR TITLE
Update Yawl to use more modern dependencies

### DIFF
--- a/lib/yawl/process.rb
+++ b/lib/yawl/process.rb
@@ -101,7 +101,7 @@ module Yawl
     end
 
     def unfinished_steps
-      steps_dataset.where("state != 'completed'")
+      steps_dataset.where(Sequel.lit("state != 'completed'"))
     end
 
     def end_state_reached

--- a/lib/yawl/version.rb
+++ b/lib/yawl/version.rb
@@ -1,3 +1,3 @@
 module Yawl
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/process_spec.rb
+++ b/spec/lib/process_spec.rb
@@ -13,10 +13,10 @@ describe Yawl::Process do
 
     @process = Yawl::Process.create(:object_type => "FakeObject", :object_id => 123, :desired_state => "tested")
     @fake_object = FakeObject.new
-    FakeObject.stub(:[]).with(123) { @fake_object }
+    allow(FakeObject).to receive(:[]).with(123) { @fake_object }
   end
 
   it "loads object" do
-    @process.object.should == @fake_object
+    expect(@process.object).to eq(@fake_object)
   end
 end

--- a/spec/lib/step_spec.rb
+++ b/spec/lib/step_spec.rb
@@ -92,7 +92,7 @@ describe Yawl::Step do
     it "executes a single step by id" do
       Yawl::Step.execute(step.id)
 
-      step.reload.state.should == "completed"
+      expect(step.reload.state).to eq("completed")
     end
   end
 
@@ -106,7 +106,7 @@ describe Yawl::Step do
 
       Yawl::Step.restart_interrupted
 
-      step.should be_queued_for_now
+      expect(step).to be_queued_for_now
     end
   end
 
@@ -118,7 +118,7 @@ describe Yawl::Step do
     it "enqueues the step for immediate execution" do
       step.start
 
-      step.should be_queued_for_now
+      expect(step).to be_queued_for_now
     end
 
     it "resets state to pending" do
@@ -126,7 +126,7 @@ describe Yawl::Step do
 
       step.start
 
-      step.state.should == "pending"
+      expect(step.state).to eq("pending")
     end
   end
 
@@ -138,11 +138,11 @@ describe Yawl::Step do
     it "sets state to completed" do
       step.execute
 
-      step.state.should == "completed"
+      expect(step.state).to eq("completed")
     end
 
     it "notifies the process of completion" do
-      step.process.should_receive(:step_finished)
+      expect(step.process).to receive(:step_finished)
 
       step.execute
     end
@@ -150,7 +150,7 @@ describe Yawl::Step do
     it "captures output" do
       step.execute
 
-      step.attempts.first.output.should == "I worked\n"
+      expect(step.attempts.first.output).to eq("I worked\n")
     end
   end
 
@@ -163,11 +163,11 @@ describe Yawl::Step do
       it "sets state to pending" do
         step.execute
 
-        step.state.should == "pending"
+        expect(step.state).to eq("pending")
       end
 
       it "does not notify the process of failure" do
-        step.process.should_not_receive(:step_failed)
+        expect(step.process).not_to receive(:step_failed)
 
         step.execute
       end
@@ -175,13 +175,13 @@ describe Yawl::Step do
       it "is queued for retry" do
         step.execute
 
-        step.should be_queued_for_later
+        expect(step).to be_queued_for_later
       end
 
       it "captures output" do
         step.execute
 
-        step.attempts.first.output.should =~ /\AI started\n\n\n---\nCAUGHT ERROR: I failed\n.*:in `.*'/ # backtrace
+        expect(step.attempts.first.output).to match(/\AI started\n\n\n---\nCAUGHT ERROR: I failed\n.*:in `.*'/) # backtrace
       end
     end
 
@@ -196,11 +196,11 @@ describe Yawl::Step do
             step.execute
           }.to raise_error(Yawl::Step::Fatal)
 
-          step.state.should == "failed"
+          expect(step.state).to eq("failed")
         end
 
         it "does not notify the process of failure" do
-          step.process.should_receive(:step_failed)
+          expect(step.process).to receive(:step_failed)
 
           expect {
             step.execute
@@ -212,7 +212,7 @@ describe Yawl::Step do
             step.execute
           }.to raise_error(Yawl::Step::Fatal)
 
-          step.should_not be_queued_for_later
+          expect(step).not_to be_queued_for_later
         end
 
         it "captures output" do
@@ -220,7 +220,7 @@ describe Yawl::Step do
             step.execute
           }.to raise_error(Yawl::Step::Fatal)
 
-          step.attempts.first.output.should =~ /\AI started\n\n\n---\nCAUGHT ERROR: Fatal error in step\n.*:in `.*'/ # backtrace
+          expect(step.attempts.first.output).to match(/\AI started\n\n\n---\nCAUGHT ERROR: Fatal error in step\n.*:in `.*'/) # backtrace
         end
       end
     end
@@ -239,11 +239,11 @@ describe Yawl::Step do
       it "sets state to failed" do
         expect { step.execute }.to raise_error
 
-        step.state.should == "failed"
+        expect(step.state).to eq("failed")
       end
 
       it "notifies the process of failure" do
-        step.process.should_receive(:step_failed)
+        expect(step.process).to receive(:step_failed)
 
         expect { step.execute }.to raise_error
       end
@@ -251,13 +251,13 @@ describe Yawl::Step do
       it "is not queued for retry" do
         expect { step.execute }.to raise_error
 
-        step.should_not be_queued_for_later
+        expect(step).not_to be_queued_for_later
       end
 
       it "captures output" do
         expect { step.execute }.to raise_error
 
-        step.attempts.first.output.should =~ /\AI started\n\n\n---\nCAUGHT ERROR: I failed\n.*:in `.*'/
+        expect(step.attempts.first.output).to match(/\AI started\n\n\n---\nCAUGHT ERROR: I failed\n.*:in `.*'/)
       end
     end
 
@@ -275,11 +275,11 @@ describe Yawl::Step do
       it "sets state to interrupted" do
         expect { step.execute }.to raise_error
 
-        step.state.should == "interrupted"
+        expect(step.state).to eq("interrupted")
       end
 
       it "does not notify the process of failure" do
-        step.process.should_not_receive(:step_failed)
+        expect(step.process).not_to receive(:step_failed)
 
         expect { step.execute }.to raise_error
       end
@@ -287,13 +287,13 @@ describe Yawl::Step do
       it "is not queued for retry" do
         expect { step.execute }.to raise_error
 
-        step.should_not be_queued_for_later
+        expect(step).not_to be_queued_for_later
       end
 
       it "captures output" do
         expect { step.execute }.to raise_error
 
-        step.attempts.first.output.should =~ /\AI started\n\n\n---\nCAUGHT ERROR: SIGTERM\n.*:in `.*'/ # backtrace
+        expect(step.attempts.first.output).to match(/\AI started\n\n\n---\nCAUGHT ERROR: SIGTERM\n.*:in `.*'/) # backtrace
       end
     end
   end
@@ -307,11 +307,11 @@ describe Yawl::Step do
       it "sets state to pending" do
         step.execute
 
-        step.state.should == "pending"
+        expect(step.state).to eq("pending")
       end
 
       it "does not notify the process of failure" do
-        step.process.should_not_receive(:step_failed)
+        expect(step.process).not_to receive(:step_failed)
 
         step.execute
       end
@@ -319,13 +319,13 @@ describe Yawl::Step do
       it "is queued for retry" do
         step.execute
 
-        step.should be_queued_for_later
+        expect(step).to be_queued_for_later
       end
 
       it "captures output" do
         step.execute
 
-        step.attempts.first.output.should =~ /\AI started\n\n\n---\nStep slept\n\Z/
+        expect(step.attempts.first.output).to match(/\AI started\n\n\n---\nStep slept\n\Z/)
       end
     end
 
@@ -343,11 +343,11 @@ describe Yawl::Step do
       it "sets state to failed" do
         expect { step.execute }.to raise_error
 
-        step.state.should == "failed"
+        expect(step.state).to eq("failed")
       end
 
       it "notifies the process of failure" do
-        step.process.should_receive(:step_failed)
+        expect(step.process).to receive(:step_failed)
 
         expect { step.execute }.to raise_error
       end
@@ -355,13 +355,13 @@ describe Yawl::Step do
       it "is not queued for retry" do
         expect { step.execute }.to raise_error
 
-        step.should_not be_queued_for_later
+        expect(step).not_to be_queued_for_later
       end
 
       it "captures output" do
         expect { step.execute }.to raise_error
 
-        step.attempts.first.output.should =~ /\AI started\n\n\n---\nStep slept\n\Z/
+        expect(step.attempts.first.output).to match(/\AI started\n\n\n---\nStep slept\n\Z/)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ require "yawl/setup"
 
 Yawl::Setup.create_for_test!
 
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+
 def QC.jobs
   s = "SELECT * FROM queue_classic_jobs"
   [QC::Conn.execute(s)].compact.flatten.
@@ -46,11 +48,11 @@ RSpec::Matchers.define :be_queued_for_later do
     QC.later_jobs.include?("q_name" => "default", "method" => "Yawl::Step.execute", "args" => [step.id])
   end
 
-  failure_message_for_should do |step|
+  failure_message do |step|
     "expected #{step.inspect} to be queued for later in later jobs #{QC.later_jobs}"
   end
 
-  failure_message_for_should_not do |step|
+  failure_message_when_negated do |step|
     "expected #{step.inspect} to not be queued for later in later jobs #{QC.later_jobs}"
   end
 end
@@ -60,11 +62,11 @@ RSpec::Matchers.define :be_queued_for_now do
     QC.jobs.include?("q_name" => "default", "method" => "Yawl::Step.execute", "args" => [step.id])
   end
 
-  failure_message_for_should do |step|
+  failure_message do |step|
     "expected #{step.inspect} to be queued for now in jobs #{QC.jobs}"
   end
 
-  failure_message_for_should_not do |step|
+  failure_message_when_negated do |step|
     "expected #{step.inspect} to not be queued for now in jobs #{QC.jobs}"
   end
 end

--- a/yawl.gemspec
+++ b/yawl.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "queue_classic", "2.2.3"
   spec.add_dependency "queue_classic-later", ">= 0.3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/yawl.gemspec
+++ b/yawl.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sequel"
   spec.add_dependency "scrolls"
-  spec.add_dependency "queue_classic"
+  spec.add_dependency "queue_classic", "2.2.3"
   spec.add_dependency "queue_classic-later", ">= 0.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
This updates Yawl so it'll work fine with the latest Sequel and Rspec dependencies. It also pins to an earlier queue_classic version due to incompatibilities that will require more work to clean up that I was putting in for this.